### PR TITLE
refactoring/substituindo-div-por-ng-container

### DIFF
--- a/ClientApp/src/app/components/product/product-card/product-card.component.html
+++ b/ClientApp/src/app/components/product/product-card/product-card.component.html
@@ -1,15 +1,16 @@
-
-<div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2
-    card pt-2 " *ngFor="let product of products" >
-      <img class="card-img-top" src="{{product.imageRef}}" alt="Card image cap">
-      <div class="card-body row">
-        <h5 class="card-title">{{product.name}}</h5>
-        <p class="card-text">{{product.description}}</p>
-        <div class="d-inline-flex col-12 col-sm-12 col-md-12 col-lg-12 col-xl-12 pl-0">
-          <div>Restantes: {{product.quantity}}</div>
+<ng-container *ngFor="let product of products">
+  <div class="col-12 col-sm-6 col-md-4 col-lg-3 col-xl-2
+      card pt-2 " *ngIf="product.id">
+        <img class="card-img-top" src="{{product.imageRef}}" alt="Card image cap">
+        <div class="card-body row">
+          <h5 class="card-title">{{product.name}}</h5>
+          <p class="card-text">{{product.description}}</p>
+          <div class="d-inline-flex col-12 col-sm-12 col-md-12 col-lg-12 col-xl-12 pl-0">
+            <div>Restantes: {{product.quantity}}</div>
+          </div>
+          <div class="d-inline-flex col-sm-12 col-md-12 col-lg-12 col-xl-12 pl-0">
+            <div>Categoria: {{product.type ? 'Orgânico': 'Inorgânico'}}</div>
+          </div>
         </div>
-        <div class="d-inline-flex col-sm-12 col-md-12 col-lg-12 col-xl-12 pl-0">
-          <div>Categoria: {{product.type ? 'Orgânico': 'Inorgânico'}}</div>
-        </div>
-      </div>
-</div>
+  </div>
+</ng-container>


### PR DESCRIPTION
Esta substituicão está sendo feito pois o Angular não coloca no DOM o ng-container pois ele é um elemento de agrupamento. Em contrapartida ele coloca uma DIV.